### PR TITLE
Imporved cli instructions and a feat to take ssh passphrase if any

### DIFF
--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -17,16 +17,12 @@ var (
 
 func NewApp() *cli.App {
 	return &cli.App{
-		Name:      "jumpstart",
-		Usage:     "jumpstart your project",
-		UsageText: "jumpstart command [command option]",
-		Version:   VERSION + "-" + COMMIT + "+" + BUILDTIME,
+		Name:    "jumpstart",
+		Usage:   "jumpstart your project",
+		Version: VERSION + "-" + COMMIT + "+" + BUILDTIME,
 		Commands: []*cli.Command{
 			{
-				Name:        "template",
-				UsageText:   "jumpstart template [sub-command]",
-				Usage:       "Perform template related actions e.g. List, Sync.",
-				Description: "Use this to list the templates supported and sync the supported templates with remote",
+				Name: "template",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "list",
@@ -56,70 +52,70 @@ func NewApp() *cli.App {
 					},
 				},
 			},
-			{
-				Name:      "create",
-				Usage:     "Create a new project with the specified supporeted template",
-				UsageText: "jumpstart create -t={supported template name} [project-name]",
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:    "template",
-						Aliases: []string{"t"},
-						Usage:   "template to use",
-					},
-				},
-				Action: func(c *cli.Context) error {
-					// Check if default template directory exists
-					_, err := os.Stat(absPath(DEFAULT_TEMPLATES_DIR))
-					if os.IsNotExist(err) {
-						fmt.Printf("Please run `jumpstart template sync` to seed templates\n\n")
-						os.Exit(2)
-					}
-
-					tid := c.String("template")
-					if tid == "" {
-						fmt.Printf("-t | --template is required\n\n")
-						cli.ShowAppHelp(c)
-						os.Exit(2)
-					}
-
-					dm, err := NewDerivedMetadata(c.Context, c.Args().First())
-					if err != nil {
-						return err
-					}
-					logrus.Infof("derived metadata: %+v", *dm)
-
-					sshKeys := NewSSHKeys()
-					{
-						count := len(sshKeys.List())
-						if count == 0 {
-							fmt.Println("No SSH keys found! Please generate one and try again!")
-							fmt.Println("See https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent for more information")
-							os.Exit(2)
-						} else if count > 1 {
-							fmt.Printf("Multiple SSH keys found! Please select one to use:\n\n")
-							for i, k := range sshKeys.List() {
-								fmt.Printf("%d. %s\n", i+1, k)
-							}
-							fmt.Printf("\nEnter selection: ")
-
-							// Read selection from user
-							var selection int
-							fmt.Scanln(&selection)
-							sshKeys.SetSelected(selection - 1)
-						}
-					}
-					fmt.Printf("\nUsing ssh key: %s\n", sshKeys.Get())
-					fmt.Print("Enter ssh passphrase if you added it while ssh-key generation: ")
-					var passphrase string
-					fmt.Scanln(&passphrase)
-					gitSSHKeys, err := ssh.NewPublicKeysFromFile("git", sshKeys.Get(), passphrase)
-					if err != nil {
-						return err
-					}
-
-					return SynthesizeProject(c.Context, tid, dm, gitSSHKeys)
-				},
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "template",
+				Aliases: []string{"t"},
+				Usage:   "template to use",
 			},
+		},
+		Action: func(c *cli.Context) error {
+			// Check if default template directory exists
+			_, err := os.Stat(absPath(DEFAULT_TEMPLATES_DIR))
+			if os.IsNotExist(err) {
+				fmt.Printf("Please run `jumpstart template sync` to seed templates\n\n")
+				os.Exit(2)
+			}
+
+			tid := c.String("template")
+			if tid == "" {
+				fmt.Printf("-t | --template is required\n\n")
+				cli.ShowAppHelp(c)
+				os.Exit(2)
+			}
+
+			dm, err := NewDerivedMetadata(c.Context, c.Args().First())
+			if err != nil {
+				return err
+			}
+			logrus.Infof("derived metadata: %+v", *dm)
+
+			sshKeys := NewSSHKeys()
+			{
+				count := len(sshKeys.List())
+				if count == 0 {
+					fmt.Println("No SSH keys found! Please generate one and try again!")
+					fmt.Println("See https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent for more information")
+					os.Exit(2)
+				} else if count > 1 {
+					fmt.Printf("Multiple SSH keys found! Please select one to use:\n\n")
+					for i, k := range sshKeys.List() {
+						fmt.Printf("%d. %s\n", i+1, k)
+					}
+					fmt.Printf("\nEnter selection: ")
+
+					// Read selection from user
+					var selection int
+					fmt.Scanln(&selection)
+					sshKeys.SetSelected(selection - 1)
+				}
+			}
+			fmt.Printf("\nUsing ssh key: %s\n", sshKeys.Get())
+			var passphrase string
+			ghSSHPassphrase, isGhSSHPassphrase := os.LookupEnv("GITHUB_SSH_PASSPHRASE")
+			if isGhSSHPassphrase {
+				passphrase = ghSSHPassphrase
+			} else {
+				fmt.Print("Enter ssh passphrase if you added it while ssh-key generation: ")
+				fmt.Scanln(&passphrase)
+			}
+			gitSSHKeys, err := ssh.NewPublicKeysFromFile("git", sshKeys.Get(), passphrase)
+			if err != nil {
+				return err
+			}
+
+			return SynthesizeProject(c.Context, tid, dm, gitSSHKeys)
 		},
 	}
 }

--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -17,12 +17,16 @@ var (
 
 func NewApp() *cli.App {
 	return &cli.App{
-		Name:    "jumpstart",
-		Usage:   "jumpstart your project",
-		Version: VERSION + "-" + COMMIT + "+" + BUILDTIME,
+		Name:      "jumpstart",
+		Usage:     "jumpstart your project",
+		UsageText: "jumpstart command [command option]",
+		Version:   VERSION + "-" + COMMIT + "+" + BUILDTIME,
 		Commands: []*cli.Command{
 			{
-				Name: "template",
+				Name:        "template",
+				UsageText:   "jumpstart template [sub-command]",
+				Usage:       "Perform template related actions e.g. List, Sync.",
+				Description: "Use this to list the templates supported and sync the supported templates with remote",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "list",
@@ -52,63 +56,70 @@ func NewApp() *cli.App {
 					},
 				},
 			},
-		},
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "template",
-				Aliases: []string{"t"},
-				Usage:   "template to use",
-			},
-		},
-		Action: func(c *cli.Context) error {
-			// Check if default template directory exists
-			_, err := os.Stat(absPath(DEFAULT_TEMPLATES_DIR))
-			if os.IsNotExist(err) {
-				fmt.Printf("Please run `jumpstart template sync` to seed templates\n\n")
-				os.Exit(2)
-			}
-
-			tid := c.String("template")
-			if tid == "" {
-				fmt.Printf("-t | --template is required\n\n")
-				cli.ShowAppHelp(c)
-				os.Exit(2)
-			}
-
-			dm, err := NewDerivedMetadata(c.Context, c.Args().First())
-			if err != nil {
-				return err
-			}
-			logrus.Infof("derived metadata: %+v", *dm)
-
-			sshKeys := NewSSHKeys()
 			{
-				count := len(sshKeys.List())
-				if count == 0 {
-					fmt.Println("No SSH keys found! Please generate one and try again!")
-					fmt.Println("See https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent for more information")
-					os.Exit(2)
-				} else if count > 1 {
-					fmt.Printf("Multiple SSH keys found! Please select one to use:\n\n")
-					for i, k := range sshKeys.List() {
-						fmt.Printf("%d. %s\n", i+1, k)
+				Name:      "create",
+				Usage:     "Create a new project with the specified supporeted template",
+				UsageText: "jumpstart create -t={supported template name} [project-name]",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "template",
+						Aliases: []string{"t"},
+						Usage:   "template to use",
+					},
+				},
+				Action: func(c *cli.Context) error {
+					// Check if default template directory exists
+					_, err := os.Stat(absPath(DEFAULT_TEMPLATES_DIR))
+					if os.IsNotExist(err) {
+						fmt.Printf("Please run `jumpstart template sync` to seed templates\n\n")
+						os.Exit(2)
 					}
-					fmt.Printf("\nEnter selection: ")
 
-					// Read selection from user
-					var selection int
-					fmt.Scanln(&selection)
-					sshKeys.SetSelected(selection - 1)
-				}
-			}
-			fmt.Printf("\nUsing ssh key: %s\n", sshKeys.Get())
+					tid := c.String("template")
+					if tid == "" {
+						fmt.Printf("-t | --template is required\n\n")
+						cli.ShowAppHelp(c)
+						os.Exit(2)
+					}
 
-			gitSSHKeys, err := ssh.NewPublicKeysFromFile("git", sshKeys.Get(), "")
-			if err != nil {
-				return err
-			}
+					dm, err := NewDerivedMetadata(c.Context, c.Args().First())
+					if err != nil {
+						return err
+					}
+					logrus.Infof("derived metadata: %+v", *dm)
 
-			return SynthesizeProject(c.Context, tid, dm, gitSSHKeys)
+					sshKeys := NewSSHKeys()
+					{
+						count := len(sshKeys.List())
+						if count == 0 {
+							fmt.Println("No SSH keys found! Please generate one and try again!")
+							fmt.Println("See https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent for more information")
+							os.Exit(2)
+						} else if count > 1 {
+							fmt.Printf("Multiple SSH keys found! Please select one to use:\n\n")
+							for i, k := range sshKeys.List() {
+								fmt.Printf("%d. %s\n", i+1, k)
+							}
+							fmt.Printf("\nEnter selection: ")
+
+							// Read selection from user
+							var selection int
+							fmt.Scanln(&selection)
+							sshKeys.SetSelected(selection - 1)
+						}
+					}
+					fmt.Printf("\nUsing ssh key: %s\n", sshKeys.Get())
+					fmt.Print("Enter ssh passphrase if you added it while ssh-key generation: ")
+					var passphrase string
+					fmt.Scanln(&passphrase)
+					gitSSHKeys, err := ssh.NewPublicKeysFromFile("git", sshKeys.Get(), passphrase)
+					if err != nil {
+						return err
+					}
+
+					return SynthesizeProject(c.Context, tid, dm, gitSSHKeys)
+				},
+			},
 		},
 	}
 }

--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -109,6 +109,7 @@ func NewApp() *cli.App {
 			} else {
 				fmt.Print("Enter ssh passphrase if you added it while ssh-key generation: ")
 				fmt.Scanln(&passphrase)
+				fmt.Print("in future you can add 'export GITHUB_SSH_PASSPHRASE=<passphrase>' to your .bashrc/.zshrc instead of re-entering here each time.\n")
 			}
 			gitSSHKeys, err := ssh.NewPublicKeysFromFile("git", sshKeys.Get(), passphrase)
 			if err != nil {

--- a/pkg/sshkeys.go
+++ b/pkg/sshkeys.go
@@ -20,6 +20,9 @@ func NewSSHKeys() *SSHKeys {
 	sshKeysDir := filepath.Join(homedir, ".ssh")
 	files, err := os.ReadDir(sshKeysDir)
 	if err != nil {
+		if strings.Contains(err.Error(), ".ssh: no such file or directory") {
+			return &SSHKeys{dir: "", keys: nil}
+		}
 		panic(err)
 	}
 

--- a/pkg/versioncontrol.go
+++ b/pkg/versioncontrol.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -41,6 +42,7 @@ func VersionControl(dir, repoName string) (*git.Repository, error) {
 		Author: &object.Signature{
 			Name:  "Jump Start",
 			Email: "jumpstart",
+			When:  time.Now(),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
1. initially we had template create cmd as `jumpstart -t [template name] {project name}` but on the other hand we have the concept of sub commands as well like `jumpstart template list` so I thought of a different approach to make command more declarative by going with option
`jumpstart create -t [template name ] {project name}`

2. when we create a ssh key for github ir prompts user to enter a phassphrase to encrypt the RSA key. previously it was hardcoded in the code now we are taking that input from the user on line no 112 to 114 in cli.go file

3. if .ssh folder does not exist in home directory we are not going for a panic now instead we return an empty instance of SSHKeys so that user knows that github ssh is not setup and he need to do it .