### PR TITLE
fix so that commands with && > | these operator work

### DIFF
--- a/pkg/synthesize.go
+++ b/pkg/synthesize.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/flosch/pongo2/v6"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -103,8 +102,7 @@ func SynthesizePipelineConfigurationFile(pipeline Pipeline, outDir string) (stri
 func runCommands(workdir string, commands []string) error {
 	var err error
 	for _, instr := range commands {
-		cag := strings.Split(instr, " ")
-		cmd := exec.Command(cag[0], cag[1:]...)
+		cmd := exec.Command("bash", "-c", instr)
 		cmd.Dir = workdir
 		if err = cmd.Run(); err != nil {
 			return fmt.Errorf("error running command '%s': %w", instr, err)


### PR DESCRIPTION
previously if we had to run commad like 
`echo "/** @type {import('next').NextConfig} */" > next.config.js` or
`cd project && npm i`
these won't work as exec.Command does not store standard output or standard err it a command fail it simply retuns an error thus causing us problem with yml files where we need to do custom nginx file addition or configuration file changes.
fix is to treat each command as a bash command as whole.